### PR TITLE
Fix Graph mode error by removing tf.function decorators

### DIFF
--- a/Kraken_XRP_ETH_SOL_AVAX_Trading_Bot_15m_GRU_LSTM_Enhanced.py
+++ b/Kraken_XRP_ETH_SOL_AVAX_Trading_Bot_15m_GRU_LSTM_Enhanced.py
@@ -563,7 +563,6 @@ def prepare_last_sequence(returns, volume, volatility, momentum, volume_anomaly)
                                       momentum[-TREND_LOOKBACK:], volume_anomaly[-TREND_LOOKBACK:]))], dtype=np.float32)
 
 
-@tf.function  # Entraînement sans XLA
 def train_model(model, X, y):
     # Détecter et choisir device (Metal GPU ou fallback CPU)
     device = "/GPU:0" if tf.config.list_physical_devices('GPU') else "/CPU:0"
@@ -649,7 +648,6 @@ def predict_price_trend(data, symbol):
         live_df['Volume_Anomaly'].values
     )
 
-    @tf.function
     def predict_batch():
         return model.predict(last_sequence, verbose=0)
 
@@ -670,7 +668,6 @@ def predict_exit(data, symbol):
                                           live_df['Volatility'].values, live_df['Momentum'].values,
                                           live_df['Volume_Anomaly'].values)
 
-    @tf.function  # Prédiction sans XLA
     def predict_batch():
         return gru_models[f'{symbol}_15min'].predict(last_sequence, verbose=0)
 


### PR DESCRIPTION
## Summary
- remove `@tf.function` decorators from training and prediction helpers

## Testing
- `python -m py_compile Kraken_XRP_ETH_SOL_AVAX_Trading_Bot_15m_GRU_LSTM_Enhanced.py`


------
https://chatgpt.com/codex/tasks/task_e_6845a6297938832c947ef09bb9887e2e