### PR TITLE
Fix profit field reading

### DIFF
--- a/Kraken_XRP_ETH_SOL_AVAX_Trading_Bot_15m_GRU_LSTM_Enhanced.py
+++ b/Kraken_XRP_ETH_SOL_AVAX_Trading_Bot_15m_GRU_LSTM_Enhanced.py
@@ -368,7 +368,7 @@ def load_transaction_history(positions, average_entry_prices):
                     action = row['action']
                     quantity = float(row['quantity'])
                     price = float(row['price'])
-                    profit = float(row['profit']) if row['profit'] else 0.0
+                    profit = float(row.get('profit', 0) or 0.0)
                     if action == 'buy':
                         current_qty = positions[symbol]
                         current_price = average_entry_prices[symbol]


### PR DESCRIPTION
## Summary
- avoid KeyError when the CSV lacks a `profit` column value

## Testing
- `pytest -q`
- `python -m py_compile Kraken_XRP_ETH_SOL_AVAX_Trading_Bot_15m_GRU_LSTM_Enhanced.py`


------
https://chatgpt.com/codex/tasks/task_e_6846c28a7bc0832ca59ca8a862e9bbc2